### PR TITLE
Make GLibc compatible with Occlum

### DIFF
--- a/OCCLUM_NOTE.md
+++ b/OCCLUM_NOTE.md
@@ -1,0 +1,23 @@
+# How to Build?
+
+The GNU C Library cannot be compiled in the source directory.  You must build it in a separate build directory.  For example, if you have unpacked the GNU C Library sources in `/src/gnu/glibc-VERSION`, create a directory `/src/gnu/glibc-build` to put the object files in.
+
+## Steps
+The steps to build Glibc for Occlum are as follows:
+
+1. Install the required modules
+```
+sudo apt-get update
+sudo apt-get install gawk bison -y
+```
+
+2. Configure, build and install Glibc
+```
+cd <glibc-build-folder>
+unset LD_LIBRARY_PATH
+CFLAGS="-O2 -g" <glibc-VERSION>/configure \
+--prefix=<glibc-install-folder> --with-tls --without-selinux --enable-stack-protector=strong --disable-nscd
+make
+make install
+```
+When completed, the resulting Glibc can be found in `<glibc-install-folder>` directory.

--- a/csu/libc-start.c
+++ b/csu/libc-start.c
@@ -214,7 +214,9 @@ LIBC_START_MAIN (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
     {
       /* This needs to run to initiliaze _dl_osversion before TLS
 	 setup might check it.  */
-      DL_SYSDEP_OSCHECK (__libc_fatal);
+      /* Occlum note: Disable the OS check in Occlum */
+      if (!IS_RUNNING_ON_OCCLUM)
+        DL_SYSDEP_OSCHECK (__libc_fatal);
     }
 # endif
 

--- a/elf/Makefile
+++ b/elf/Makefile
@@ -29,11 +29,15 @@ routines	= $(all-dl-routines) dl-support dl-iteratephdr \
 
 # The core dynamic linking functions are in libc for the static and
 # profiled libraries.
+# Occlum note: Define the global symbol `__occlum_entry` in ld.so
 dl-routines	= $(addprefix dl-,load lookup object reloc deps hwcaps \
 				  runtime init fini debug misc \
 				  version profile tls origin scope \
 				  execstack caller open close trampoline \
-				  exception sort-maps)
+				  exception sort-maps) occlum_entry
+
+CFLAGS-occlum_entry.c = -fPIC
+
 ifeq (yes,$(use-ldconfig))
 dl-routines += dl-cache
 endif

--- a/elf/Versions
+++ b/elf/Versions
@@ -79,4 +79,8 @@ ld {
     # Set value of a tunable.
     __tunable_get_val;
   }
+  OCCLUM {
+    # Occlum syscall address
+    __occlum_entry;
+  }
 }

--- a/elf/dl-sysdep.c
+++ b/elf/dl-sysdep.c
@@ -177,6 +177,12 @@ _dl_sysdep_start (void **start_argptr,
 	GLRO(dl_sysinfo_dso) = (void *) av->a_un.a_val;
 	break;
 #endif
+      /* Occlum note: Init the __occlum_entry from the aux vector,
+         Occlum has set the value of aux vector entry to the address
+         of Occlum's syscall handler. */
+      case AT_OCCLUM_ENTRY:
+	__occlum_entry = (void *)av->a_un.a_val;
+	break;
       case AT_RANDOM:
 	_dl_random = (void *) av->a_un.a_val;
 	break;

--- a/elf/elf.h
+++ b/elf/elf.h
@@ -20,6 +20,7 @@
 #define	_ELF_H 1
 
 #include <features.h>
+#include "occlum_entry.h"
 
 __BEGIN_DECLS
 
@@ -1201,6 +1202,9 @@ typedef struct
 #define AT_L2_CACHEGEOMETRY	45
 #define AT_L3_CACHESIZE		46
 #define AT_L3_CACHEGEOMETRY	47
+
+/* Occlum note: Store the address of Occlum's syscall handler */
+#define AT_OCCLUM_ENTRY 48
 
 /* Note section contents.  Each entry in the note section begins with
    a header of a fixed form.  */

--- a/elf/occlum_entry.c
+++ b/elf/occlum_entry.c
@@ -1,0 +1,4 @@
+#include "occlum_entry.h"
+
+/* Occlum note: Address of Occlum's syscall handler */
+void *__occlum_entry = 0;

--- a/elf/occlum_entry.h
+++ b/elf/occlum_entry.h
@@ -1,0 +1,7 @@
+#ifndef _OCCLUM_ENTRY_H
+#define _OCCLUM_ENTRY_H
+
+extern void *__occlum_entry;
+#define IS_RUNNING_ON_OCCLUM      (__occlum_entry != 0)
+
+#endif /* _OCCLUM_ENTRY_H */

--- a/elf/rtld.c
+++ b/elf/rtld.c
@@ -1313,7 +1313,9 @@ of this helper program; chances are you did not intend to run this program.\n\
   setup_vdso (main_map, &first_preload);
 
 #ifdef DL_SYSDEP_OSCHECK
-  DL_SYSDEP_OSCHECK (_dl_fatal_printf);
+  /* Occlum note: Disable the OS check in Occlum */
+  if (!IS_RUNNING_ON_OCCLUM)
+    DL_SYSDEP_OSCHECK (_dl_fatal_printf);
 #endif
 
   /* Initialize the data structures for the search paths for shared

--- a/sysdeps/nptl/fork.c
+++ b/sysdeps/nptl/fork.c
@@ -47,6 +47,11 @@ fresetlockfiles (void)
 pid_t
 __libc_fork (void)
 {
+  if (IS_RUNNING_ON_OCCLUM) {
+    /* Occlum note: Occlum does NOT support fork, use posix_spawn instead. */
+    errno = ENOSYS;
+    return -1;
+  }
   pid_t pid;
   struct used_handler
   {

--- a/sysdeps/unix/sysv/linux/access.c
+++ b/sysdeps/unix/sysv/linux/access.c
@@ -26,7 +26,8 @@ __access (const char *file, int type)
 #ifdef __NR_access
   return INLINE_SYSCALL_CALL (access, file, type);
 #else
-  return INLINE_SYSCALL_CALL (faccessat, AT_FDCWD, file, type);
+  /* Occlum note: Occlum accepts the 4th argument */
+  return INLINE_SYSCALL_CALL (faccessat, AT_FDCWD, file, type, 0);
 #endif
 }
 weak_alias (__access, access)

--- a/sysdeps/unix/sysv/linux/dl-sysdep.h
+++ b/sysdeps/unix/sysv/linux/dl-sysdep.h
@@ -25,7 +25,6 @@
 
 #define NEED_DL_SYSINFO_DSO	1
 
-
 #ifndef __ASSEMBLER__
 /* Get version of the OS.  */
 extern int _dl_discover_osversion (void) attribute_hidden;

--- a/sysdeps/unix/sysv/linux/faccessat.c
+++ b/sysdeps/unix/sysv/linux/faccessat.c
@@ -33,8 +33,10 @@ faccessat (int fd, const char *file, int mode, int flag)
   if (flag & ~(AT_SYMLINK_NOFOLLOW | AT_EACCESS))
     return INLINE_SYSCALL_ERROR_RETURN_VALUE (EINVAL);
 
-  if ((flag == 0 || ((flag & ~AT_EACCESS) == 0 && ! __libc_enable_secure)))
-    return INLINE_SYSCALL (faccessat, 3, fd, file, mode);
+  if ((flag == 0 || ((flag & ~AT_EACCESS) == 0 && ! __libc_enable_secure))) {
+    /* Occlum note: Occlum accepts the 4th argument */
+    return INLINE_SYSCALL (faccessat, 4, fd, file, mode, flag);
+  }
 
   struct stat64 stats;
   if (__fxstatat64 (_STAT_VER, fd, file, &stats, flag & AT_SYMLINK_NOFOLLOW))

--- a/sysdeps/unix/sysv/linux/spawni.c
+++ b/sysdeps/unix/sysv/linux/spawni.c
@@ -396,6 +396,16 @@ __spawnix (pid_t * pid, const char *file,
   return ec;
 }
 
+static int
+__spawni_on_occlum (pid_t * pid, const char *file,
+		    const posix_spawn_file_actions_t * acts,
+		    const posix_spawnattr_t * attrp, char *const argv[],
+		    char *const envp[])
+{
+  int ret = syscall(__NR_spawn, pid, file, argv, envp, acts, attrp);
+  return ret;
+}
+
 /* Spawn a new process executing PATH with the attributes describes in *ATTRP.
    Before running the process perform the actions described in FILE-ACTIONS. */
 int
@@ -404,6 +414,10 @@ __spawni (pid_t * pid, const char *file,
 	  const posix_spawnattr_t * attrp, char *const argv[],
 	  char *const envp[], int xflags)
 {
+  if (IS_RUNNING_ON_OCCLUM) {
+    /* Occlum note: Call syscall directly */
+    return __spawni_on_occlum(pid, file, acts, attrp, argv, envp);
+  }
   return __spawnix (pid, file, acts, attrp, argv, envp, xflags,
 		    xflags & SPAWN_XFLAGS_USE_PATH ? __execvpe : __execve);
 }

--- a/sysdeps/unix/sysv/linux/sysdep-vdso.h
+++ b/sysdeps/unix/sysv/linux/sysdep-vdso.h
@@ -41,7 +41,7 @@
 									      \
     __typeof (__vdso_##name) vdsop = __vdso_##name;			      \
     PTR_DEMANGLE (vdsop);						      \
-    if (vdsop != NULL)							      \
+    if (vdsop != NULL && !IS_RUNNING_ON_OCCLUM)				      \
       {									      \
 	sc_ret = INTERNAL_VSYSCALL_CALL (vdsop, sc_err, nr, ##args);	      \
 	if (!INTERNAL_SYSCALL_ERROR_P (sc_ret, sc_err))			      \
@@ -68,7 +68,7 @@
 									      \
     __typeof (__vdso_##name) vdsop = __vdso_##name;			      \
     PTR_DEMANGLE (vdsop);						      \
-    if (vdsop != NULL)							      \
+    if (vdsop != NULL && !IS_RUNNING_ON_OCCLUM)				      \
       {									      \
 	v_ret = INTERNAL_VSYSCALL_CALL (vdsop, err, nr, ##args);	      \
 	if (!INTERNAL_SYSCALL_ERROR_P (v_ret, err)			      \

--- a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
+++ b/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
@@ -84,7 +84,7 @@ ENTRY(____longjmp_chk)
 	xorl	%edi, %edi
 	lea	-sizeSS(%rsp), %RSI_LP
 	movl	$__NR_sigaltstack, %eax
-	syscall
+	OCCLUM_SYSCALL
 	/* Without working sigaltstack we cannot perform the test.  */
 	testl	%eax, %eax
 	jne	.Lok2

--- a/sysdeps/unix/sysv/linux/x86_64/cancellation.S
+++ b/sysdeps/unix/sysv/linux/x86_64/cancellation.S
@@ -109,7 +109,7 @@ ENTRY(__pthread_disable_asynccancel)
 	xorq	%r10, %r10
 	addq	$CANCELHANDLING, %rdi
 	LOAD_PRIVATE_FUTEX_WAIT (%esi)
-	syscall
+	OCCLUM_SYSCALL
 	movl	%fs:CANCELHANDLING, %eax
 	jmp	3b
 END(__pthread_disable_asynccancel)

--- a/sysdeps/unix/sysv/linux/x86_64/clone.S
+++ b/sysdeps/unix/sysv/linux/x86_64/clone.S
@@ -47,6 +47,29 @@
 
 
         .text
+	.global __thread_start_on_occlum
+	.hidden __thread_start_on_occlum
+	.type   __thread_start_on_occlum,@function
+__thread_start_on_occlum:
+	// 16(%rsp) - void* args
+	mov 16(%rsp), %rdi
+	// 8(%rsp)  - int(*func)(void*)
+	mov 8(%rsp), %rcx
+	// Make %rsp 16-aligned before call
+	and $-16, %rsp
+	// Call user-given thread function
+	call *%rcx
+
+	// Call exit syscall
+	//  int syscall_num - %rdi
+	//  int exit_code - %rsi
+	mov $SYS_ify(exit), %rdi
+	mov %rax, %rsi
+	call syscall@GOTPCREL(%rip)
+
+	// This should never happen!
+	hlt
+
 ENTRY (__clone)
 	/* Sanity check arguments.  */
 	movq	$-EINVAL,%rax
@@ -55,6 +78,42 @@ ENTRY (__clone)
 	testq	%rsi,%rsi		/* no NULL stack pointers */
 	jz	SYSCALL_ERROR_LABEL
 
+	// Is running on Occlum?
+	movq __occlum_entry@GOTPCREL(%rip), %r11
+	movq (%r11), %r11
+	cmpq $0, %r11
+	je __clone_on_x84_64
+	//
+	// Pass args to the stack of the child
+	//
+	// Save child stack addr into another scratch register
+	mov %rsi, %r10
+	// Make child stack addr 16-byte aligned initially
+	and $-16, %r10
+	// Push args into the stack of the child
+	sub $8, %r10
+	mov %rcx, (%r10)
+	// Push func into the stack of the child
+	sub $8, %r10
+	mov %rdi, (%r10)
+	// Push "return address" for syscall
+	// LibOS will find the entry point of the child by popping
+	// the value from the top of the stack of the new thread.
+	sub $8, %r10
+	mov __thread_start_on_occlum@GOTPCREL(%rip), %r11
+	mov %r11, (%r10)
+
+	/* Do the system call.  */
+	mov $SYS_ify(clone), %rdi
+	mov %rdx, %rsi
+	mov %r10, %rdx
+	mov %r8, %rcx
+	mov 8(%rsp), %r8
+	call syscall@GOTPCREL(%rip)
+
+	jmp __end
+
+__clone_on_x84_64:
 	/* Insert the argument onto the new stack.  */
 	subq	$16,%rsi
 	movq	%rcx,8(%rsi)
@@ -79,6 +138,7 @@ ENTRY (__clone)
 	jl	SYSCALL_ERROR_LABEL
 	jz	L(thread_start)
 
+__end:
 	ret
 
 L(thread_start):

--- a/sysdeps/unix/sysv/linux/x86_64/getcontext.S
+++ b/sysdeps/unix/sysv/linux/x86_64/getcontext.S
@@ -75,7 +75,7 @@ ENTRY(__getcontext)
 #endif
 	movl	$_NSIG8,%r10d
 	movl	$__NR_rt_sigprocmask, %eax
-	syscall
+	OCCLUM_SYSCALL
 	cmpq	$-4095, %rax		/* Check %rax for error.  */
 	jae	SYSCALL_ERROR_LABEL	/* Jump to error handler if error.  */
 

--- a/sysdeps/unix/sysv/linux/x86_64/lowlevellock.S
+++ b/sysdeps/unix/sysv/linux/x86_64/lowlevellock.S
@@ -90,7 +90,7 @@ __lll_lock_wait_private:
 
 1:	LIBC_PROBE (lll_lock_wait_private, 1, %rdi)
 	movl	$SYS_futex, %eax
-	syscall
+	OCCLUM_SYSCALL
 
 2:	movl	%edx, %eax
 	xchgl	%eax, (%rdi)	/* NB:	 lock is implied */
@@ -130,7 +130,7 @@ __lll_lock_wait:
 
 1:	LIBC_PROBE (lll_lock_wait, 2, %rdi, %rsi)
 	movl	$SYS_futex, %eax
-	syscall
+	OCCLUM_SYSCALL
 
 2:	movl	%edx, %eax
 	xchgl	%eax, (%rdi)	/* NB:	 lock is implied */
@@ -185,7 +185,7 @@ __lll_timedlock_wait:
 
 1:	movl	$SYS_futex, %eax
 	movl	$2, %edx
-	syscall
+	OCCLUM_SYSCALL
 
 2:	xchgl	%edx, (%rdi)	/* NB:   lock is implied */
 
@@ -279,7 +279,7 @@ __lll_timedlock_wait:
 	LOAD_FUTEX_WAIT (%esi)
 	movq	%r12, %rdi
 	movl	$SYS_futex, %eax
-	syscall
+	OCCLUM_SYSCALL
 
 	/* NB: %edx == 2 */
 	xchgl	%edx, (%r12)
@@ -336,7 +336,7 @@ __lll_unlock_wake_private:
 	LOAD_PRIVATE_FUTEX_WAKE (%esi)
 	movl	$1, %edx	/* Wake one thread.  */
 	movl	$SYS_futex, %eax
-	syscall
+	OCCLUM_SYSCALL
 
 	popq	%rdx
 	cfi_adjust_cfa_offset(-8)
@@ -366,7 +366,7 @@ __lll_unlock_wake:
 	LOAD_FUTEX_WAKE (%esi)
 	movl	$1, %edx	/* Wake one thread.  */
 	movl	$SYS_futex, %eax
-	syscall
+	OCCLUM_SYSCALL
 
 	popq	%rdx
 	cfi_adjust_cfa_offset(-8)
@@ -436,7 +436,7 @@ __lll_timedwait_tid:
 #endif
 	movq	%r12, %rdi
 	movl	$SYS_futex, %eax
-	syscall
+	OCCLUM_SYSCALL
 
 	cmpl	$0, (%rdi)
 	jne	1f

--- a/sysdeps/unix/sysv/linux/x86_64/occlum_syscall.h
+++ b/sysdeps/unix/sysv/linux/x86_64/occlum_syscall.h
@@ -1,0 +1,36 @@
+#ifndef _OCCLUM_SYSCALL_H_
+#define _OCCLUM_SYSCALL_H_
+
+#ifdef __ASSEMBLER__
+.text
+.macro OCCLUM_SYSCALL
+    // Is running on Occlum?
+    movq __occlum_entry@GOTPCREL(%rip), %r11
+    movq (%r11), %r11
+    cmpq $0, %r11
+    je 688f
+    // Do Occlum syscall
+    lea 699f(%rip), %rcx
+    jmp *%r11
+688:
+    // Do Linux syscall
+    syscall
+699:
+.endm
+#else /* !__ASSEMBLER__ */
+asm (
+".text\r\n"
+".macro OCCLUM_SYSCALL\r\n"
+"movq __occlum_entry@GOTPCREL(%rip), %r11\r\n"
+"movq (%r11), %r11\r\n"
+"cmpq $0, %r11\r\n"
+"je 688f\r\n"
+"lea 699f(%rip), %rcx\r\n"
+"jmp *%r11\r\n"
+"688:\r\n"
+"syscall\r\n"
+"699:\r\n"
+".endm\r\n");
+#endif /* __ASSEMBLER__ */
+
+#endif /* _OCCLUM_SYSCALL_H_ */

--- a/sysdeps/unix/sysv/linux/x86_64/setcontext.S
+++ b/sysdeps/unix/sysv/linux/x86_64/setcontext.S
@@ -43,7 +43,7 @@ ENTRY(__setcontext)
 	movl	$SIG_SETMASK, %edi
 	movl	$_NSIG8,%r10d
 	movl	$__NR_rt_sigprocmask, %eax
-	syscall
+	OCCLUM_SYSCALL
 	popq	%rdi			/* Reload %rdi, adjust stack.  */
 	cfi_adjust_cfa_offset(-8)
 	cmpq	$-4095, %rax		/* Check %rax for error.  */

--- a/sysdeps/unix/sysv/linux/x86_64/sigaction.c
+++ b/sysdeps/unix/sysv/linux/x86_64/sigaction.c
@@ -120,7 +120,7 @@ asm									\
    "	.type __" #name ",@function\n"					\
    "__" #name ":\n"							\
    "	movq $" #syscall ", %rax\n"					\
-   "	syscall\n"							\
+   "	OCCLUM_SYSCALL\n"						\
    ".LEND_" #name ":\n"							\
    ".section .eh_frame,\"a\",@progbits\n"				\
    ".LSTARTFRAME_" #name ":\n"						\

--- a/sysdeps/unix/sysv/linux/x86_64/swapcontext.S
+++ b/sysdeps/unix/sysv/linux/x86_64/swapcontext.S
@@ -75,7 +75,7 @@ ENTRY(__swapcontext)
 	movl	$SIG_SETMASK, %edi
 	movl	$_NSIG8,%r10d
 	movl	$__NR_rt_sigprocmask, %eax
-	syscall
+	OCCLUM_SYSCALL
 	cmpq	$-4095, %rax		/* Check %rax for error.  */
 	jae	SYSCALL_ERROR_LABEL	/* Jump to error handler if error.  */
 

--- a/sysdeps/unix/sysv/linux/x86_64/syscall.S
+++ b/sysdeps/unix/sysv/linux/x86_64/syscall.S
@@ -34,7 +34,7 @@ ENTRY (syscall)
 	movq %r8, %r10
 	movq %r9, %r8
 	movq 8(%rsp),%r9	/* arg6 is on the stack.  */
-	syscall			/* Do the system call.  */
+	OCCLUM_SYSCALL		/* Do the system call.  */
 	cmpq $-4095, %rax	/* Check %rax for error.  */
 	jae SYSCALL_ERROR_LABEL	/* Jump to error handler if error.  */
 	ret			/* Return to caller.  */

--- a/sysdeps/unix/sysv/linux/x86_64/sysdep.h
+++ b/sysdeps/unix/sysv/linux/x86_64/sysdep.h
@@ -22,6 +22,7 @@
 #include <sysdeps/unix/sysv/linux/sysdep.h>
 #include <sysdeps/unix/x86_64/sysdep.h>
 #include <tls.h>
+#include "occlum_syscall.h"
 
 #if IS_IN (rtld)
 # include <dl-sysdep.h>		/* Defines RTLD_PRIVATE_ERRNO.  */
@@ -50,6 +51,10 @@
 # define __NR_semtimedop 220
 #endif
 
+/* Occlum note: A specific syscall number to handle posix_spawn in Occlum */
+#ifndef __NR_spawn
+# define __NR_spawn 359
+#endif
 
 #ifdef __ASSEMBLER__
 
@@ -177,7 +182,7 @@
 # define DO_CALL(syscall_name, args)		\
     DOARGS_##args				\
     movl $SYS_ify (syscall_name), %eax;		\
-    syscall;
+    OCCLUM_SYSCALL;
 
 # define DOARGS_0 /* nothing */
 # define DOARGS_1 /* nothing */
@@ -241,7 +246,7 @@
 ({									\
     unsigned long int resultvar;					\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number)							\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
@@ -255,7 +260,7 @@
     TYPEFY (arg1, __arg1) = ARGIFY (arg1);			 	\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1)						\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
@@ -271,7 +276,7 @@
     register TYPEFY (arg2, _a2) asm ("rsi") = __arg2;			\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2)				\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
@@ -289,7 +294,7 @@
     register TYPEFY (arg2, _a2) asm ("rsi") = __arg2;			\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3)			\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
@@ -309,7 +314,7 @@
     register TYPEFY (arg2, _a2) asm ("rsi") = __arg2;			\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3), "r" (_a4)		\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
@@ -331,7 +336,7 @@
     register TYPEFY (arg2, _a2) asm ("rsi") = __arg2;			\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3), "r" (_a4),		\
       "r" (_a5)								\
@@ -356,7 +361,7 @@
     register TYPEFY (arg2, _a2) asm ("rsi") = __arg2;			\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
-    "syscall\n\t"							\
+    "OCCLUM_SYSCALL\n\t"						\
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3), "r" (_a4),		\
       "r" (_a5), "r" (_a6)						\

--- a/sysdeps/unix/sysv/linux/x86_64/vfork.S
+++ b/sysdeps/unix/sysv/linux/x86_64/vfork.S
@@ -36,7 +36,7 @@ ENTRY (__vfork)
 
 	/* Stuff the syscall number in RAX and enter into the kernel.  */
 	movl	$SYS_ify (vfork), %eax
-	syscall
+	OCCLUM_SYSCALL
 
 	/* Push back the return PC.  */
 	pushq	%rdi

--- a/sysdeps/x86_64/hp-timing.h
+++ b/sysdeps/x86_64/hp-timing.h
@@ -17,6 +17,11 @@
    <http://www.gnu.org/licenses/>.  */
 
 #ifndef _HP_TIMING_H
+
+#include <sysdeps/generic/hp-timing.h>
+/* Occlum note: Disable the HP_TIMING because rdtsc is an exception in SGXv1,
+   it is too slow to handle it, maybe we can enable it in SGXv2 */
+#if 0
 #define _HP_TIMING_H	1
 
 /* We always assume having the timestamp register.  */
@@ -36,5 +41,5 @@ typedef unsigned long long int hp_timing_t;
      (Var) = ((unsigned long long int) _hi << 32) | _lo; })
 
 #include <hp-timing-common.h>
-
+#endif
 #endif /* hp-timing.h */

--- a/sysdeps/x86_64/nptl/tls.h
+++ b/sysdeps/x86_64/nptl/tls.h
@@ -144,7 +144,7 @@ typedef struct
      _head->self = _thrdescr;						      \
 									      \
      /* It is a simple syscall to set the %fs value for the thread.  */	      \
-     asm volatile ("syscall"						      \
+     asm volatile ("OCCLUM_SYSCALL"					      \
 		   : "=a" (_result)					      \
 		   : "0" ((unsigned long int) __NR_arch_prctl),		      \
 		     "D" ((unsigned long int) ARCH_SET_FS),		      \


### PR DESCRIPTION
1. Redirect syscalls into Occlum
2. Support posix_spawn syscall for Occlum
3. Modify vdso to calling syscalls in Occlum
4. Disable the OSCHECK and  HP_TIMING in Occlum